### PR TITLE
Fix/graduates scroll

### DIFF
--- a/src/hooks/usePreventBodyScrollOutlet/index.ts
+++ b/src/hooks/usePreventBodyScrollOutlet/index.ts
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+import { useOutlet } from "react-router-dom";
+
+/**
+ * prevent document.body from scrolling when has child route
+ * if otherwise, scrolling in position `fixed` will scroll body too
+ *
+ * Reference:
+ * https://stackoverflow.com/a/9280412
+ */
+function usePreventBodyScrollOutlet() {
+  const outletElement = useOutlet();
+
+  useEffect(() => {
+    if (outletElement) document.body.style.overflow = "hidden";
+    else document.body.style.overflow = "visible";
+  }, [outletElement]);
+
+  return outletElement;
+}
+
+export default usePreventBodyScrollOutlet;

--- a/src/pages/graduates/GraduateCard/index.tsx
+++ b/src/pages/graduates/GraduateCard/index.tsx
@@ -13,7 +13,7 @@ const GraduateCard: React.FC<GraduateCardProps> = ({ graduate }) => {
   return (
     <S.StyledCard>
       <CardActionArea>
-        <SS.Link to={`/graduates/${graduate.id}`}>
+        <SS.Link to={`/graduates/${graduate.id}`} preventScrollReset>
           <S.StyledImageContainer>
             <S.StyledGraduateImage
               graduateName={graduate.name}

--- a/src/pages/graduates/Graduates.tsx
+++ b/src/pages/graduates/Graduates.tsx
@@ -1,14 +1,15 @@
 import { CircularProgress, Typography } from "@mui/material";
 import graduatesData from "assets/json/graduates_public.json";
+import usePreventBodyScrollOutlet from "hooks/usePreventBodyScrollOutlet";
 import React, { useState } from "react";
 import { useInView } from "react-intersection-observer";
-import { Outlet } from "react-router-dom";
 import { Graduate } from "./graduates.interface";
 import GridLayout from "./GridLayout";
 
 const pageSize = 20;
 
 function Graduates() {
+  const outletElement = usePreventBodyScrollOutlet();
   const [graduates, setGraduates] = useState<Graduate[]>(() =>
     graduatesData.slice(0, pageSize)
   );
@@ -40,7 +41,7 @@ function Graduates() {
           )}
         </footer>
       </section>
-      <Outlet />
+      {outletElement}
     </>
   );
 }

--- a/src/pages/graduates/Graduates.tsx
+++ b/src/pages/graduates/Graduates.tsx
@@ -2,6 +2,7 @@ import { CircularProgress, Typography } from "@mui/material";
 import graduatesData from "assets/json/graduates_public.json";
 import React, { useState } from "react";
 import { useInView } from "react-intersection-observer";
+import { Outlet } from "react-router-dom";
 import { Graduate } from "./graduates.interface";
 import GridLayout from "./GridLayout";
 
@@ -24,20 +25,23 @@ function Graduates() {
   });
 
   return (
-    <section style={{ margin: 16 }}>
-      <main>
-        <GridLayout graduates={graduates} />
-      </main>
-      <footer ref={ref}>
-        {canScrollFurther ? (
-          <div style={{ textAlign: "center" }}>
-            <CircularProgress />
-          </div>
-        ) : (
-          <Typography align="right">{`${graduates.length} graduate(s)`}</Typography>
-        )}
-      </footer>
-    </section>
+    <>
+      <section style={{ margin: 16 }}>
+        <main>
+          <GridLayout graduates={graduates} />
+        </main>
+        <footer ref={ref}>
+          {canScrollFurther ? (
+            <div style={{ textAlign: "center" }}>
+              <CircularProgress />
+            </div>
+          ) : (
+            <Typography align="right">{`${graduates.length} graduate(s)`}</Typography>
+          )}
+        </footer>
+      </section>
+      <Outlet />
+    </>
   );
 }
 

--- a/src/pages/graduates/details/ImageHolder/index.tsx
+++ b/src/pages/graduates/details/ImageHolder/index.tsx
@@ -12,7 +12,7 @@ const ImageHolder: React.FC<ImageHolderProps> = ({ graduate }) => {
   return (
     <>
       <S.ImageToolbar>
-        <Link to="/graduates">
+        <Link to="/graduates" preventScrollReset>
           <ContainedIconButton edge="start" aria-label="close" size="small">
             <ArrowBack />
           </ContainedIconButton>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -17,9 +17,9 @@ const routes: RouteObject[] = [
       { index: true, element: <Home /> },
       {
         path: "graduates",
+        element: <Graduates />,
         errorElement: <ErrorElement />,
         children: [
-          { index: true, element: <Graduates /> },
           {
             path: ":graduateId",
             element: <GraduateDetails />,


### PR DESCRIPTION
## Related Issue(s)

- 

## Describe Your Changes

- navigate from `/graduates` to `/graduates/:id` then back to `/graduates` , instead of restore scroll to top, user should continue scroll from where they left off
- fix UI/UX scroll bug when at `/graduates/:id`, user should not allow to scroll document.body


## Screenshots

-

## Additional Notes

-
